### PR TITLE
Add molotov to the list of weapons blocked from spawnning

### DIFF
--- a/scripts/vscripts/pyroholic.nut
+++ b/scripts/vscripts/pyroholic.nut
@@ -3,7 +3,7 @@ DirectorOptions <-
 {
   	weaponsToRemove =
  	{
-	//	<Weapon script name>	= 0
+	  weapon_molotov           = 0
           weapon_pipe_bomb         = 0
           weapon_vomitjar          = 0
           weapon_pistol            = 0


### PR DESCRIPTION
Since molotovs are given to the player from the scripts they don't need to spawn in game world